### PR TITLE
Fixed typo: "stopWebDribver" to "stopWebDriver"

### DIFF
--- a/src/main/java/org/openmrs/uitestframework/test/TestBase.java
+++ b/src/main/java/org/openmrs/uitestframework/test/TestBase.java
@@ -148,7 +148,7 @@ public class TestBase implements SauceOnDemandSessionIdProvider {
 	}
 
 	@After
-	public void stopWebDribver() {
+	public void stopWebDriver() {
 		driver.quit();
 	}
 


### PR DESCRIPTION
Fixed spelling of “stopWebDriver”
