### PR TITLE
Update Selenium Dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
 			<artifactId>selenium-java</artifactId>
-			<version>2.45.0</version>
+			<version>2.52.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>

--- a/src/main/java/org/openmrs/uitestframework/test/TestBase.java
+++ b/src/main/java/org/openmrs/uitestframework/test/TestBase.java
@@ -148,7 +148,7 @@ public class TestBase implements SauceOnDemandSessionIdProvider {
 	}
 
 	@After
-	public void stopWebDribver() {
+	public void stopWebDriver() {
 		driver.quit();
 	}
 


### PR DESCRIPTION
- Updated Selenium to 2.52.0
- This allows the tests to work on Firefox 45
- Also fixed a typo: ‘stopWebDribver’ to ‘stopWebDriver’
- Relevant Ticket: https://issues.openmrs.org/browse/RA-1081 
