### PR TITLE
Increased global maximum timeout value from 15s to 30s

### DIFF
--- a/src/main/java/org/openmrs/uitestframework/test/TestBase.java
+++ b/src/main/java/org/openmrs/uitestframework/test/TestBase.java
@@ -62,7 +62,7 @@ import com.saucelabs.junit.SauceOnDemandTestWatcher;
  */
 public class TestBase implements SauceOnDemandSessionIdProvider {
 
-	public static final int MAX_WAIT_SECONDS = 15;
+	public static final int MAX_WAIT_SECONDS = 30;
 
 	public String sessionId;
 


### PR DESCRIPTION
According to this @rkorytkowski  jira comment:
https://issues.openmrs.org/browse/RA-1102?focusedCommentId=231921&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-231921
