### PR TITLE
Increased max timeout from 30s to 60s

### DIFF
--- a/src/main/java/org/openmrs/uitestframework/test/TestBase.java
+++ b/src/main/java/org/openmrs/uitestframework/test/TestBase.java
@@ -62,7 +62,7 @@ import com.saucelabs.junit.SauceOnDemandTestWatcher;
  */
 public class TestBase implements SauceOnDemandSessionIdProvider {
 
-	public static final int MAX_WAIT_SECONDS = 30;
+	public static final int MAX_WAIT_SECONDS = 60;
 
 	public String sessionId;
 


### PR DESCRIPTION
I've checked out sauce labs test execution and it seems that 30 secs is not enough to find toast element.
Thats because it takes 15 seconds to save patiend AND THEN it needs few more secs to get new page.
Problem is caused by sauce labs which needs about addational 20 seconds to load new page.
