### PR TITLE
Revert "Using buildNumber as a tunnel identifier"

### DIFF
--- a/src/main/java/org/openmrs/uitestframework/test/TestBase.java
+++ b/src/main/java/org/openmrs/uitestframework/test/TestBase.java
@@ -158,7 +158,11 @@ public class TestBase implements SauceOnDemandSessionIdProvider {
 					buildNumber += "-" + branch;
 				}
 				capabilities.setCapability("build", buildNumber);
-				capabilities.setCapability("tunnel-identifier", buildNumber);
+			}
+
+			String tunnelIdentifier = System.getProperty("tunnel.identifier");
+			if (!StringUtils.isBlank(tunnelIdentifier)) {
+				capabilities.setCapability("tunnel-identifier", tunnelIdentifier);
 			}
 
 			driver = new RemoteWebDriver(new URL("http://" + sauceLabsAuthentication.getUsername() + ":"


### PR DESCRIPTION
Reverts openmrs/openmrs-contrib-uitestframework#28
