### PR TITLE
RA-1295: added methods createLocation and permanentDelete

### DIFF
--- a/src/main/java/org/openmrs/uitestframework/test/TestData.java
+++ b/src/main/java/org/openmrs/uitestframework/test/TestData.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -113,7 +112,13 @@ public class TestData {
 
 	}
 
+	/**
+	 * https://wiki.openmrs.org/display/docs/REST+Web+Service+Resources+in+OpenMRS+1.9#RESTWebServiceResourcesinOpenMRS1.9-Location
+	 */
 	public static class TestLocation extends JsonTestClass {
+
+		public String name;
+		public List<String> tags;
 
 		public TestLocation(String name) {
 			this.name = name;
@@ -124,9 +129,6 @@ public class TestData {
 			this.name = name;
 			this.tags = tags;
 		}
-
-		public String name;
-		public List<String> tags;
 
 		@Override
 		public String name() {
@@ -574,6 +576,32 @@ public class TestData {
 		person.uuid = tp.create();
 		person.id = getPersonId(person.uuid);
 		return person.uuid;
+	}
+	
+	/**
+	 *Create a location without tags
+	 *
+	 * @param locationName the name of the location
+	 * @return the location's uuid
+	 */
+	
+	public static String createLocation(String locationName){
+		
+		TestLocation testLocation = new TestLocation(locationName);
+		return testLocation.create();
+	}
+	/**
+	 * Delete a resource permanently
+	 * 
+	 * @param uuid of the resource
+	 */
+	
+	
+	public static void permanetDelete(String uuid){
+		
+		if(null != uuid && !uuid.isEmpty()){
+			RestClient.delete(uuid, true);
+		}	
 	}
 
 	public static final String BDAY_SEP = "-";

--- a/src/main/java/org/openmrs/uitestframework/test/TestData.java
+++ b/src/main/java/org/openmrs/uitestframework/test/TestData.java
@@ -599,7 +599,7 @@ public class TestData {
 	
 	public static void permanetDelete(String uuid){
 		
-		if(null != uuid && StringUtils.isNotBlank(uuid)){
+		if(StringUtils.isNotBlank(uuid)){
 			RestClient.delete(uuid, true);
 		}	
 	}

--- a/src/main/java/org/openmrs/uitestframework/test/TestData.java
+++ b/src/main/java/org/openmrs/uitestframework/test/TestData.java
@@ -599,7 +599,7 @@ public class TestData {
 	
 	public static void permanetDelete(String uuid){
 		
-		if(null != uuid && !uuid.isEmpty()){
+		if(null != uuid && StringUtils.isNotBlank(uuid)){
 			RestClient.delete(uuid, true);
 		}	
 	}

--- a/src/main/java/org/openmrs/uitestframework/test/TestData.java
+++ b/src/main/java/org/openmrs/uitestframework/test/TestData.java
@@ -584,19 +584,17 @@ public class TestData {
 	 * @param locationName the name of the location
 	 * @return the location's uuid
 	 */
-	
 	public static String createLocation(String locationName){
 		
 		TestLocation testLocation = new TestLocation(locationName);
 		return testLocation.create();
 	}
+
 	/**
 	 * Delete a resource permanently
 	 * 
 	 * @param uuid of the resource
 	 */
-	
-	
 	public static void permanetDelete(String uuid){
 		
 		if(StringUtils.isNotBlank(uuid)){


### PR DESCRIPTION
TestData has been extended with the method createLocation and permanentDelete.
The method permanentDelete deletes any resource given a valid uuid. This method is out of scope of issue RA-1295, but it is necessary if you need to delete a resource such as location (this was in my case). 
I ask to the reviewer if the permanetDelete can be accepted with this pull request and if it is a decent solution to delete a resource.
PS: 
if you have received a former pull request (it should be #32 ), please ignore it. I had to recreate the branch RA-1295 because of a bad commit. 