### PR TITLE
RATEST-133: Failure when findElement() function is invoked

### DIFF
--- a/src/main/java/org/openmrs/uitestframework/page/Page.java
+++ b/src/main/java/org/openmrs/uitestframework/page/Page.java
@@ -152,7 +152,7 @@ public abstract class Page {
     }
 
     public WebElement findElement(By by) {
-        waiter.until(ExpectedConditions.visibilityOfElementLocated(by));
+        waiter.until(ExpectedConditions.presenceOfElementLocated(by));
 
         return driver.findElement(by);
     }


### PR DESCRIPTION
Ticket ID: https://issues.openmrs.org/browse/RATEST-133

Description:
Whenever findElement() function is invoked by the test instances in the legacy ui to retrieve elements present on a given page, the required element is not retrievable and TimeOutException is thrown with a message Waiting for visibility of element.